### PR TITLE
Travis: Build release and debug in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ before_script:
   - ./configure 
   - make 
 
+env:
+  - TEST_TARGET=debug
+  - TEST_TARGET=release
+
 script: 
-  - ./runtest.pl ALL debug 
-  - ./runtest.pl ALL release
+  - ./runtest.pl ALL $TEST_TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: cpp
+
 branches:
   only:
     - master
+
 compiler:
   - gcc
   - clang
+
 cache: apt
+
 sudo: false
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: cpp
 
-branches:
-  only:
-    - master
-
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
This parallelizes the build process. I also activated building on all branches as this allows running travis outside master, which is rather convenient when wanting to test the branch before making a pull-request. 