### PR TITLE
Add a test for reading and writing BackupStoreDirectory binary data

### DIFF
--- a/lib/backupstore/BackupStoreDirectory.cpp
+++ b/lib/backupstore/BackupStoreDirectory.cpp
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------
 //
 // File
-//		Name:    BackupStoreDirectory.h
+//		Name:    BackupStoreDirectory.cpp
 //		Purpose: Representation of a backup directory
 //		Created: 2003/08/26
 //
@@ -172,7 +172,7 @@ void BackupStoreDirectory::ReadFromStream(IOStream &rStream, int Timeout)
 	int count = ntohl(hdr.mNumEntries);
 
 	// Clear existing list
-	for(std::vector<Entry*>::iterator i = mEntries.begin(); 
+	for(std::vector<Entry*>::iterator i = mEntries.begin();
 		i != mEntries.end(); i++)
 	{
 		delete (*i);

--- a/lib/backupstore/BackupStoreDirectory.cpp
+++ b/lib/backupstore/BackupStoreDirectory.cpp
@@ -36,11 +36,6 @@ typedef struct
 	// Then a StreamableMemBlock for attributes
 } dir_StreamFormat;
 
-typedef enum
-{
-	Option_DependencyInfoPresent = 1
-} dir_StreamFormatOptions;
-
 typedef struct
 {
 	uint64_t mModificationTime;

--- a/lib/backupstore/BackupStoreDirectory.h
+++ b/lib/backupstore/BackupStoreDirectory.h
@@ -47,6 +47,11 @@ public:
 	}
 #endif
 
+	typedef enum
+	{
+		Option_DependencyInfoPresent = 1
+	} dir_StreamFormatOptions;
+
 	BackupStoreDirectory();
 	BackupStoreDirectory(int64_t ObjectID, int64_t ContainerID);
 	// Convenience constructor from a stream


### PR DESCRIPTION
See discussion of incompatible struct packing on ARM processors:
http://mailman.uk.freebsd.org/pipermail../public/boxbackup/2010-November/005818.html
    
Thanks to Leif Linderstam for identifying the problem and proposing a solution. This is just a test for the problem, not a fix in itself.
