### PR TITLE
Fix version generation from pure-Git checkouts.

### DIFF
--- a/infrastructure/BoxPlatform.pm.in
+++ b/infrastructure/BoxPlatform.pm.in
@@ -17,19 +17,21 @@ BEGIN
 	if ($^O eq "MSWin32" and not -x "/usr/bin/uname")
 	{
 		$build_os = "winnt";
+		eval "use Win32";
+		$build_os_ver = Win32::GetOSName();
 	}
 	else
 	{
 		$build_os = `uname`;
+		$build_os_ver = `uname -r`;
 		chomp $build_os;
+		chomp $build_os_ver;
 	}
 
 	# Cygwin Builds usually something like CYGWIN_NT-5.0, CYGWIN_NT-5.1
 	# Box Backup tried on Win2000,XP only :)
 	$build_os = 'CYGWIN' if $build_os =~ m/CYGWIN/;
 	$build_os = 'MINGW32' if $build_os =~ m/MINGW32/;
-	$build_os_ver = `uname -r`;
-	chomp $build_os_ver;
 
 	if ($build_os eq 'Darwin') {
 		$xcode_ver = `xcodebuild -version | awk '/^Xcode/ {print \$2}'`
@@ -81,44 +83,10 @@ BEGIN
 
 	if($product_version =~ /USE_SVN_VERSION/)
 	{
-		# for developers, use SVN version
-		my $svnversion = 'unknown';
-		my $svnurl = 'unknown';
-
-		if(-d '.svn')
-		{
-			my $svnversion = `svnversion .`;
-			chomp $svnversion;
-			$svnversion =~ tr/0-9A-Za-z/_/c;
-			open INFO,'svn info . |';
-			while(<INFO>)
-			{
-				if(m/^URL: (.+?)[\n\r]+/)
-				{
-					$svnurl = $1
-				}
-			}
-			close INFO;
-		}
-		elsif(-d '.git')
-		{
-			$svnversion = `git svn info | grep '^Revision:' | cut -d' ' -f2`;
-			chomp $svnversion;
-			$svnurl = `git svn info --url`;
-		}
-
-		my $svndir;
-		if ($svnurl =~ m!/box/(.+)$!)
-		{
-			$svndir = $1;
-		}
-		elsif ($svnurl =~ m'/(boxi/.+)/boxi/boxbackup')
-		{
-			$svndir = $1;
-		}
-
-		$svndir =~ tr/0-9A-Za-z/_/c;
-		$product_version =~ s/USE_SVN_VERSION/$svndir.'_'.$svnversion/e;
+		# for developers, use Git version (SVN is no more):
+		my $gitversion = `git rev-parse HEAD`;
+		chomp $gitversion;
+		$product_version =~ s/USE_SVN_VERSION/git_$gitversion/;
 	}
 
 	# where to put the files


### PR DESCRIPTION
Fix calls to Uname on platforms that don't have it, such as MSVC.

Do this in a way that doesn't break platforms without the Win32 Perl module,
thanks to @jamesog for spotting this and for the suggested fix!

Fixes #10.

commit 2db3e7a096f6748410c56626ca50e5c69ad1119f
Author: Chris Wilson <chris+github@qwirx.com>
Date:   Sun Dec 6 12:02:21 2015 +0000