### PR TITLE
Build Win32/64 binary packages automatically

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}-{branch}
+version: 0.12.{branch}.appveyor_{build}
 
 clone_depth: 1
 
@@ -8,25 +8,34 @@ skip_tags: true
 os: Windows Server 2012
 
 platform:
-# - x86
-# - x64
-  - Win32
+  - Win32 # CMake sucks
+  - x64
 
 configuration:
   - Debug
   - Release
 
 environment:
-  VisualStudioVersion: 10.0
-  Generator: Visual Studio 10
+  VisualStudioVersion: 11.0
+  Generator_Base: Visual Studio 11 2012
   OPENSSL_VERSION: 1.0.2f
   PCRE_VERSION: 8.38
   CMAKE_UNIBUILD_DIR: '%APPVEYOR_BUILD_FOLDER%\..\cmake'
+  BOXBACKUP_VERSION_BASE: 0.12
 
 init:
 # Uncomment the following two lines to enable RDP access to the virtual machine for debugging.
 # - reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
 # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: $env:date_string = Get-Date -Format "yyMMdd"
+  - ps: $env:sane_platform = $($env:PLATFORM.replace("Win32", "x86"))
+  # http://help.appveyor.com/discussions/problems/2874-how-can-i-add-commit-id-to-build-version
+  - ps: $env:boxbackup_version_full="$env:BOXBACKUP_VERSION_BASE.$env:APPVEYOR_REPO_BRANCH.$env:date_string.$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
+  - ps: Update-AppveyorBuild -Version "$env:boxbackup_version_full"
+  - ps: $env:compiled_version="$($env:boxbackup_version_full)_Win_$($env:sane_platform)_$($env:CONFIGURATION)"
+  # The only way to switch between 32-bit and 64-bit compilers appears to be to append " Win64"
+  # to the generator name if you want a 64-bit build (x64 platform):
+  - ps: $env:generator_name="$($env:Generator_Base)$(if ($env:PLATFORM.equals('x64')) {' Win64'})"
 
 build:
   parallel: true
@@ -35,15 +44,15 @@ build:
 
 install:
   # test_bbackupd needs 7zip (or cmake -E tar) to extract tar archives on Windows:
-  - cinst -y --limit-output 7zip.commandline
-  # Install cmake.portable instead of cmake, to get it on the path again:
-  # http://disq.us/p/xdknrt
+  - cinst -y --limit-output 7zip.commandline nsis.portable
   - dir "c:\Program Files"
   - dir "c:\Program Files (x86)"
   # We don't need strawberryperl on AppVeyor because there is already a Perl in c:\Perl.
   # If you are doing this on a fresh box for development, you would probably want to
   # install Chocolatey and then run:
-  # cinst -y cmake strawberryperl git vim visualstudio2012wdx
+  # cinst -y cmake.portable strawberryperl git vim visualstudio2012wdx
+  # We install cmake.portable instead of cmake, to get it on the path again
+  # <http://disq.us/p/xdknrt>.
 
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
   - if not exist %CMAKE_UNIBUILD_DIR% md %CMAKE_UNIBUILD_DIR%
@@ -51,7 +60,12 @@ install:
   # We need to specify the generator here, in case the user has more than one installed.
   # CMake always seems to default to the latest version of Visual Studio, not the one on
   # the current PATH.
-  - cmake -G "%Generator%" -A %PLATFORM% %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
+  - echo cmake -G "%generator_name%" -DDEBUG=1
+    -DBOXBACKUP_VERSION=%compiled_version%
+    %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
+  - cmake -G "%generator_name%" -DDEBUG=1
+    -DBOXBACKUP_VERSION=%compiled_version%
+    %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
 
   # Leave the current directory in the correct place to find the solution file using its relative path above.
 
@@ -62,4 +76,27 @@ test_script:
   # - dir %PLATFORM%
   # - dir %PLATFORM%\%CONFIGURATION%
   - ctest -C %CONFIGURATION% -V --interactive-debug-mode 0
+
+  # After running tests successfully, and before collecting artifacts, build them and copy them
+  # to the right place:
+  - cmake --build . --config %CONFIGURATION% --target package
+
+  # AppVeyor refuses to package files outside of the project directory, so we need to push them:
+  - dir
+  - appveyor PushArtifact -path BoxBackup-%compiled_version%.zip -DeploymentName BoxBackup-%compiled_version%
+  - appveyor PushArtifact -path BoxBackup-%compiled_version%.exe -DeploymentName BoxBackup-%compiled_version%
+
+deploy:
+  - provider: GitHub
+    release: BoxBackup-$(boxbackup_version_full)
+    artifact: BoxBackup-$(compiled_version)
+    description: "Windows client binaries auto-built by AppVeyor"
+    draft: false
+    prerelease: true
+    auth_token:
+      secure: WZi3MJGA5zIIAAij0if4auYeltJlyWUOePTYlCGvrNrgEVjYRkqILHzvVKDnLn43
+    on:
+      branch:
+        - master
+        - s3_support_merge
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,11 @@ build:
   project: ..\cmake\BoxBackup_Windows.sln
   verbosity: minimal
 
+# Remove Xamarin to remove 500 lines of junk from build logs
+# http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
+before_build:
+  - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
+
 install:
   # test_bbackupd needs 7zip (or cmake -E tar) to extract tar archives on Windows:
   - cinst -y --limit-output 7zip.commandline nsis.portable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,9 +58,11 @@ install:
   # the current PATH.
   - echo cmake -G "%generator_name%" -DDEBUG=1
     -DBOXBACKUP_VERSION=%compiled_version%
+    -DSUB_CMAKE_EXTRA_ARGS="-- /verbosity:minimal"
     %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
   - cmake -G "%generator_name%" -DDEBUG=1
     -DBOXBACKUP_VERSION=%compiled_version%
+    -DSUB_CMAKE_EXTRA_ARGS="-- /verbosity:minimal"
     %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
 
   # Leave the current directory in the correct place to find the solution file using its relative path above.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,16 +37,7 @@ init:
   # to the generator name if you want a 64-bit build (x64 platform):
   - ps: $env:generator_name="$($env:Generator_Base)$(if ($env:PLATFORM.equals('x64')) {' Win64'})"
 
-build:
-  parallel: true
-  project: ..\cmake\BoxBackup_Windows.sln
-  verbosity: minimal
-
-# Remove Xamarin to remove 500 lines of junk from build logs
-# http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
-before_build:
-  - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
-
+# scripts that run after cloning repository (before the build step, not after!)
 install:
   # test_bbackupd needs 7zip (or cmake -E tar) to extract tar archives on Windows:
   - cinst -y --limit-output 7zip.commandline nsis.portable
@@ -74,6 +65,16 @@ install:
 
   # Leave the current directory in the correct place to find the solution file using its relative path above.
 
+# Remove Xamarin to remove 500 lines of junk from build logs
+# http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
+before_build:
+  - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
+
+build:
+  parallel: true
+  project: ..\cmake\BoxBackup_Windows.sln
+  verbosity: minimal
+
 test_script:
   - cd %CMAKE_UNIBUILD_DIR%\Build\boxbackup
   # - dir
@@ -82,8 +83,7 @@ test_script:
   # - dir %PLATFORM%\%CONFIGURATION%
   - ctest -C %CONFIGURATION% -V --interactive-debug-mode 0
 
-  # After running tests successfully, and before collecting artifacts, build them and copy them
-  # to the right place:
+  # After running tests successfully, build the artifacts that we want to upload:
   - cmake --build . --config %CONFIGURATION% --target package
 
   # AppVeyor refuses to package files outside of the project directory, so we need to push them:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,5 +105,5 @@ deploy:
     on:
       branch:
         - master
-        - s3_support_merge
+        - windows_binary_packages
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,11 +56,11 @@ install:
   # We need to specify the generator here, in case the user has more than one installed.
   # CMake always seems to default to the latest version of Visual Studio, not the one on
   # the current PATH.
-  - echo cmake -G "%generator_name%" -DDEBUG=1
+  - echo cmake -G "%generator_name%"
     -DBOXBACKUP_VERSION=%compiled_version%
     -DSUB_CMAKE_EXTRA_ARGS="-- /verbosity:minimal"
     %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows
-  - cmake -G "%generator_name%" -DDEBUG=1
+  - cmake -G "%generator_name%"
     -DBOXBACKUP_VERSION=%compiled_version%
     -DSUB_CMAKE_EXTRA_ARGS="-- /verbosity:minimal"
     %APPVEYOR_BUILD_FOLDER%\infrastructure\cmake\windows

--- a/infrastructure/cmake/CMakeLists.txt
+++ b/infrastructure/cmake/CMakeLists.txt
@@ -78,25 +78,38 @@ foreach(file_to_configure ${files_to_configure})
 		"${base_dir}/${file_to_configure}.out")
 endforeach()
 
-# Work out the current Box version (requires Perl) and update lib/common/BoxVersion.h,
-# but only if it has changed, to avoid unnecessary complete rebuilds due to timestamps.
-execute_process(
-	COMMAND ${PERL_EXECUTABLE} ${base_dir}/infrastructure/cmake/getversion.pl
-	WORKING_DIRECTORY ${base_dir}/infrastructure
-	RESULT_VARIABLE status
-	OUTPUT_VARIABLE new_version_define
-	ERROR_VARIABLE command_output)
-if(NOT status EQUAL 0)
-	message(FATAL_ERROR "Failed to execute: "
-		"${PERL_EXECUTABLE} ${base_dir}/infrastructure/cmake/getversion.pl: "
-		"status ${status}: ${command_output}")
+# If BOXBACKUP_VERSION is defined when running CMake (as the AppVeyor config does), use it
+# as-is, since it contains the full version number, branch, and platform (Win32/Win64):
+if(BOXBACKUP_VERSION)
+	set(boxbackup_version ${BOXBACKUP_VERSION})
+	# Remove CPACK_SYSTEM_NAME from the default CPACK_PACKAGE_NAME, because it's already
+	# included in the CPACK_PACKAGE_VERSION:
+	set(CPACK_PACKAGE_FILE_NAME ${CMAKE_PROJECT_NAME}-${boxbackup_version})
+else()
+	# Work out the current Box version (requires Perl) and update lib/common/BoxVersion.h,
+	# but only if it has changed, to avoid unnecessary complete rebuilds due to timestamps.
+	execute_process(
+		COMMAND ${PERL_EXECUTABLE} ${base_dir}/infrastructure/cmake/getversion.pl
+		WORKING_DIRECTORY ${base_dir}/infrastructure
+		RESULT_VARIABLE status
+		OUTPUT_VARIABLE boxbackup_version
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_VARIABLE command_output)
+	if(NOT status EQUAL 0)
+		message(FATAL_ERROR "Failed to execute: "
+			"${PERL_EXECUTABLE} ${base_dir}/infrastructure/cmake/getversion.pl: "
+			"status ${status}: ${command_output}")
+	endif()
 endif()
-file(WRITE "${base_dir}/lib/common/BoxVersion.h.new" "${new_version_define}")
+
+file(WRITE "${base_dir}/lib/common/BoxVersion.h.new"
+	"#define BOX_VERSION \"${boxbackup_version}\"\n")
 replace_file_if_different(
 	"${base_dir}/lib/common/BoxVersion.h"
 	"${base_dir}/lib/common/BoxVersion.h.new")
 
 add_definitions(-DBOX_CMAKE -DNEED_BOX_VERSION_H)
+
 if(WIN32)
 	add_definitions(-DWIN32)
 endif()
@@ -331,6 +344,16 @@ foreach(module_dep ${module_deps})
 	endif()
 endforeach()
 
+if(WIN32)
+	install(FILES ${base_dir}/bin/bbackupd/win32/NotifySysAdmin.vbs
+		DESTINATION "." COMPONENT Extras)
+	install(FILES ${base_dir}/bin/bbackupd/win32/bbackupd.conf
+		DESTINATION "." COMPONENT Extras)
+else()
+	install(FILES ${base_dir}/bin/bbackupd/bbackupd-config
+		DESTINATION "." COMPONENT Extras)
+endif()
+
 # We can't do anything conditional on CMAKE_BUILD_TYPE because that's not valid for multi-configuration
 # generators such as MSVC. We need to use a generator expression instead.
 target_compile_definitions(lib_common PUBLIC $<$<CONFIG:Release>:BOX_RELEASE_BUILD>)
@@ -353,9 +376,6 @@ if(WIN32)
 	target_link_libraries(lib_common PUBLIC ws2_32 gdi32)
 endif()
 
-# Link to ZLib
-# http://stackoverflow.com/a/6174604/648162
-include_directories(${base_dir}/../zlib-win32/include)
 # On Windows we want to statically link zlib to make debugging and distribution easier,
 # but FindZLIB.cmake doesn't offer that as an option, so we have to go through some
 # contortions to "find" the correct library. ZLIB_ROOT is required in this case.
@@ -688,3 +708,18 @@ set_tests_properties(backupdiff PROPERTIES TIMEOUT 32)
 set_tests_properties(bbackupd PROPERTIES TIMEOUT 1200)
 set_tests_properties(s3store PROPERTIES TIMEOUT 20)
 set_tests_properties(httpserver PROPERTIES TIMEOUT 40)
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Box Backup is an open source, completely automatic, on-line backup system")
+set(CPACK_PACKAGE_VENDOR "www.BoxBackup.org")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${base_dir}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${base_dir}/LICENSE.txt")
+set(CPACK_PACKAGE_VERSION ${boxbackup_version})
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "Box Backup")
+set(CPACK_COMPONENTS_ALL Applications Extras)
+set(CPACK_GENERATOR "ZIP;NSIS")
+set(CPACK_NSIS_DISPLAY_NAME "Box Backup")
+set(CPACK_NSIS_HELP_LINK "http://www.boxbackup.org/")
+set(CPACK_NSIS_URL_INFO_ABOUT "http://www.boxbackup.org/")
+set(CPACK_NSIS_CONTACT "boxbackup@boxbackup.org")
+set(CPACK_NSIS_MODIFY_PATH ON)
+include(CPack)

--- a/infrastructure/cmake/getversion.pl
+++ b/infrastructure/cmake/getversion.pl
@@ -8,6 +8,6 @@ chdir $basedir or die "Failed to change to base directory: $basedir: $!";
 
 require "$basedir/infrastructure/BoxPlatform.pm.in";
 
-print "#define BOX_VERSION \"$BoxPlatform::product_version\"\n";
+print "$BoxPlatform::product_version\n";
 
 exit 0;

--- a/infrastructure/cmake/windows/CMakeLists.txt
+++ b/infrastructure/cmake/windows/CMakeLists.txt
@@ -35,7 +35,7 @@ ExternalProject_Add(zlib
 	URL "http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
 	URL_HASH ${ZLIB_HASH}
 	DOWNLOAD_NO_PROGRESS 1
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${install_dir}
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${install_dir} ${SUB_CMAKE_EXTRA_ARGS}
 	# We need to build both versions, debug and release, because cmake requires both to be
 	# present to generate its multi-configuration project files for Visual Studio/MSBuild.
 	INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target install --config Debug
@@ -86,7 +86,7 @@ ExternalProject_Add(pcre
 	SVN_REPOSITORY svn://vcs.exim.org/pcre/code/trunk
 	SVN_REVISION -r 1677
 	DOWNLOAD_NO_PROGRESS 1
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${install_dir}
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${install_dir} ${SUB_CMAKE_EXTRA_ARGS}
 	-DPCRE_SUPPORT_LIBREADLINE=OFF
 	-DPCRE_SUPPORT_LIBBZ2=OFF
 	# We need to build both versions, debug and release, because cmake requires both to be
@@ -122,5 +122,6 @@ ExternalProject_Add(boxbackup
 		-DAPPVEYOR_MODE=1
 		-DDEBUG=${DEBUG}
 		${boxbackup_cmake_args}
+		${SUB_CMAKE_EXTRA_ARGS}
 	STEP_TARGETS configure build install
 )

--- a/infrastructure/cmake/windows/CMakeLists.txt
+++ b/infrastructure/cmake/windows/CMakeLists.txt
@@ -100,9 +100,9 @@ ExternalProject_Add(boost
 	URL "http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_UNDERSCORES}.tar.bz2"
 	URL_HASH ${BOOST_HASH}
 	# DOWNLOAD_NO_PROGRESS 1
-	CONFIGURE_COMMAND "" # none needed
-	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "No build step needed" # none needed
-	INSTALL_COMMAND "" # none needed
+	CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "No configure step needed"
+	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "No build step needed"
+	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "No install step needed"
 )
 
 if(BOXBACKUP_VERSION)
@@ -119,6 +119,7 @@ ExternalProject_Add(boxbackup
 		-DPCRE_ROOT=${install_dir}
 		-DBOOST_ROOT=${CMAKE_BINARY_DIR}/Source/boost
 		-DBOX_SUPPORT_READLINE=OFF
+		-DCMAKE_INSTALL_PREFIX=${install_dir}
 		-DAPPVEYOR_MODE=1
 		-DDEBUG=${DEBUG}
 		${boxbackup_cmake_args}

--- a/lib/common/Timer.cpp
+++ b/lib/common/Timer.cpp
@@ -151,7 +151,6 @@ void Timers::AssertInitialised()
 void Timers::Add(Timer& rTimer)
 {
 	ASSERT(spTimers);
-	ASSERT(&rTimer);
 	BOX_TRACE(TIMER_ID_OF(rTimer) " added to global queue, rescheduling");
 	spTimers->push_back(&rTimer);
 	Reschedule();
@@ -168,8 +167,6 @@ void Timers::Add(Timer& rTimer)
 // --------------------------------------------------------------------------
 void Timers::Remove(Timer& rTimer)
 {
-	ASSERT(&rTimer);
-
 	if(!spTimers)
 	{
 		BOX_WARNING(TIMER_ID_OF(rTimer) " was still active after "

--- a/test/common/testcommon.cpp
+++ b/test/common/testcommon.cpp
@@ -312,10 +312,11 @@ int test(int argc, const char *argv[])
 	// Check that using timer methods without initialisation
 	// throws an assertion failure. Can only do this in debug mode
 	#ifndef BOX_RELEASE_BUILD
-		TEST_CHECK_THROWS(Timers::Add(*(Timer*)NULL), 
-			CommonException, AssertFailed);
-		TEST_CHECK_THROWS(Timers::Remove(*(Timer*)NULL), 
-			CommonException, AssertFailed);
+	{
+		Timer tim(0, "tim");
+		TEST_CHECK_THROWS(Timers::Add(tim), CommonException, AssertFailed);
+		Timers::Remove(tim);
+	}
 	#endif
 
 	// TEST_CHECK_THROWS(Timers::Signal(), CommonException, AssertFailed);


### PR DESCRIPTION
Every AppVeyor build on the specified branches that passes will be packaged into a ZIP file and NSIS installer using CPack, and uploaded to GitHub Releases.