### PR TITLE
Fix compatibility with OpenSSL 1.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ configuration:
 environment:
   VisualStudioVersion: 11.0
   Generator_Base: Visual Studio 11 2012
-  OPENSSL_VERSION: 1.0.2f
+  OPENSSL_VERSION: 1.1.0f
   PCRE_VERSION: 8.38
   CMAKE_UNIBUILD_DIR: '%APPVEYOR_BUILD_FOLDER%\..\cmake'
   BOXBACKUP_VERSION_BASE: 0.12

--- a/infrastructure/cmake/CMakeLists.txt
+++ b/infrastructure/cmake/CMakeLists.txt
@@ -407,7 +407,26 @@ else()
 endif()
 
 # Link to OpenSSL
-find_package(OpenSSL REQUIRED)
+# Workaround for incorrect library suffixes searched by FindOpenSSL:
+# https://gitlab.kitware.com/cmake/cmake/issues/17604
+if(WIN32 AND MSVC)
+	find_package(OpenSSL)
+	set(OPENSSL_SSL_LIBRARY ${SSL_EAY_RELEASE})
+	set(OPENSSL_CRYPTO_LIBRARY ${LIB_EAY_RELEASE})
+	set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} crypt32)
+	find_package_handle_standard_args(OpenSSL
+	REQUIRED_VARS
+		OPENSSL_SSL_LIBRARY
+		OPENSSL_CRYPTO_LIBRARY
+		OPENSSL_INCLUDE_DIR
+	VERSION_VAR
+		OPENSSL_VERSION
+	FAIL_MESSAGE
+		"Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR"
+	)
+else()
+	find_package(OpenSSL REQUIRED)
+endif()
 include_directories(${OPENSSL_INCLUDE_DIR})
 target_link_libraries(lib_crypto PUBLIC ${OPENSSL_LIBRARIES})
 

--- a/infrastructure/cmake/windows/CMakeLists.txt
+++ b/infrastructure/cmake/windows/CMakeLists.txt
@@ -15,9 +15,9 @@ set(ZLIB_VERSION    1.2.11)
 set(ZLIB_HASH SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1)
 
 # Version of OpenSSL to download, build, and compile Box Backup against:
-set(OPENSSL_VERSION 1.0.2j)
+set(OPENSSL_VERSION 1.1.0g)
 # Hash of openssl-${OPENSSL_VERSION}.tar.gz, to be verified after download:
-set(OPENSSL_HASH SHA256=e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431)
+set(OPENSSL_HASH SHA256=de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af)
 
 # Version of PCRE to download, build, and compile Box Backup against:
 set(PCRE_VERSION    8.39)
@@ -49,15 +49,21 @@ if(WIN32)
 		URL "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
 		URL_HASH ${OPENSSL_HASH}
 		DOWNLOAD_NO_PROGRESS 1
-		CONFIGURE_COMMAND perl Configure debug-VC-WIN32 no-asm --prefix=${install_dir}
-		COMMAND cmd /c ms\\do_ms.bat
+		CONFIGURE_COMMAND perl Configure debug-VC-WIN32 no-asm no-shared
+			--prefix=${install_dir}
+			--openssldir=etc
+		# Run tests before install, but don't make the main target depend on them, so that
+		# we don't have to run them whenever we build manually on Windows.
+		TEST_BEFORE_INSTALL 1
+		TEST_EXCLUDE_FROM_MAIN 1
 		# You would expect us to use nt.mak to compile a static library here, but mk1mf.pl uses the /MT[d]
 		# CRT in that case, which is incompatible with our dynamic runtime, /MD[d]. It seems that the libs
 		# built by ntdll.mak, which are compiled with /MD[d], are full libraries and not import libs,
 		# so we can link statically against them and still get a dynamic runtime.
 		BUILD_IN_SOURCE 1
-		BUILD_COMMAND   nmake /s /f ms\\nt.mak
-		INSTALL_COMMAND nmake /s /f ms\\nt.mak install
+		BUILD_COMMAND   nmake /s
+		TEST_COMMAND    nmake /s test
+		INSTALL_COMMAND nmake /s install
 	)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	ExternalProject_Add(openssl

--- a/infrastructure/cmake/windows/CMakeLists.txt
+++ b/infrastructure/cmake/windows/CMakeLists.txt
@@ -126,5 +126,6 @@ ExternalProject_Add(boxbackup
 		-DDEBUG=${DEBUG}
 		${boxbackup_cmake_args}
 		${SUB_CMAKE_EXTRA_ARGS}
-	STEP_TARGETS configure build install
+	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "No install step needed"
+	STEP_TARGETS configure build
 )

--- a/infrastructure/cmake/windows/CMakeLists.txt
+++ b/infrastructure/cmake/windows/CMakeLists.txt
@@ -100,6 +100,8 @@ ExternalProject_Add(boost
 	URL "http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_UNDERSCORES}.tar.bz2"
 	URL_HASH ${BOOST_HASH}
 	# DOWNLOAD_NO_PROGRESS 1
+	# Disable automatic updating (untarring) as it's slow and not necessary
+	UPDATE_DISCONNECTED 1
 	CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "No configure step needed"
 	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "No build step needed"
 	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "No install step needed"

--- a/infrastructure/m4/boxbackup_tests.m4
+++ b/infrastructure/m4/boxbackup_tests.m4
@@ -357,4 +357,10 @@ fi
 ;;
 esac
 
-
+AC_CHECK_PROGS(default_debugger, [lldb gdb])
+AC_ARG_WITH([debugger],
+            [AS_HELP_STRING([--with-debugger=<gdb|lldb|...>],
+              [use this debugger in t-gdb scripts to debug tests @<:@default=lldb if present, otherwise gdb@:>@])],
+            [],
+            [with_debugger=$default_debugger])
+AC_SUBST([with_debugger])

--- a/infrastructure/makebuildenv.pl.in
+++ b/infrastructure/makebuildenv.pl.in
@@ -391,6 +391,9 @@ if ($target_windows)
 print "done\n\nGenerating Makefiles...\n";
 
 my $makefile_ifdef_prefix = $bsd_make ? "." : "";
+my $autoconf_cppflags = '@CPPFLAGS@';
+my $autoconf_cxxflags = '@CXXFLAGS_STRICT@';
+my $autoconf_ldflags  = '@LDFLAGS@';
 
 open MASTER_MAKEFILE, ">Makefile" or die "Makefile: $!";
 print MASTER_MAKEFILE <<__E;
@@ -412,13 +415,13 @@ WINDRES = @WINDRES@
 
 # Work around a mistake in QDBM (using <angled> includes for a file not in the
 # system path) by adding it to the include path with -I.
-DEFAULT_CFLAGS = \@CPPFLAGS@ $default_cflags \@CXXFLAGS_STRICT@ \\
+DEFAULT_CFLAGS = $autoconf_cppflags $default_cflags $autoconf_cxxflags \\
 	$extra_platform_defines $platform_compile_line_extra \\
 	-DBOX_VERSION="\\"$product_version\\"" -Iqdbm
-DEFAULT_CXXFLAGS = \@CPPFLAGS@ $default_cxxflags \@CXXFLAGS_STRICT@ \\
+DEFAULT_CXXFLAGS = $autoconf_cppflags $default_cxxflags $autoconf_cxxflags \\
 	$extra_platform_defines $platform_compile_line_extra \\
 	-DBOX_VERSION="\\"$product_version\\""
-LDFLAGS += \@LDFLAGS@ \@LDADD_RDYNAMIC@ $platform_link_line_extra
+LDFLAGS += $autoconf_ldflags \@LDADD_RDYNAMIC@ $platform_link_line_extra
 
 RELEASE_CFLAGS   = \$(DEFAULT_CFLAGS)   -DBOX_RELEASE_BUILD $release_flags
 RELEASE_CXXFLAGS = \$(DEFAULT_CXXFLAGS) -DBOX_RELEASE_BUILD $release_flags

--- a/infrastructure/makebuildenv.pl.in
+++ b/infrastructure/makebuildenv.pl.in
@@ -379,6 +379,7 @@ $default_cflags =~ s/ -O2//g;
 $default_cxxflags =~ s/ -O2//g;
 my $debug_base_dir = 'debug';
 my $release_base_dir = 'release';
+my $debugger = '@with_debugger@';
 
 my $release_flags = "-O2";
 if ($target_windows)
@@ -614,9 +615,18 @@ __E
 		
 		writetestfile("$mod/t", "GLIBCXX_FORCE_NEW=1 ".
 			'./_test' . $platform_exe_ext . ' "$@"', $mod);
-		writetestfile("$mod/t-gdb", "GLIBCXX_FORCE_NEW=1 ".
-			'gdb ./_test' . $platform_exe_ext . ' "$@"', $mod);
-		
+
+		if($debugger)
+		{
+			writetestfile("$mod/t-gdb", "GLIBCXX_FORCE_NEW=1 ".
+				$debugger . ' ./_test' . $platform_exe_ext . ' "$@"', $mod);
+		}
+		else
+		{
+			writetestfile("$mod/t-gdb",
+				"echo 'No debugger was detected by configure script'\n".
+				"exit 2");
+		}
 	}
 	
 	my @all_deps_for_module;

--- a/lib/crypto/CipherBlowfish.cpp
+++ b/lib/crypto/CipherBlowfish.cpp
@@ -206,7 +206,7 @@ void CipherBlowfish::SetupParameters(EVP_CIPHER_CTX *pCipherContext) const
 	}
 	// Set key
 #ifndef HAVE_OLD_SSL
-	if(EVP_CipherInit_ex(pCipherContext, NULL, NULL, (unsigned char*)mpKey, (unsigned char*)mpInitialisationVector, -1) != 1)
+	if(EVP_CipherInit_ex(pCipherContext, GetCipher(), NULL, (unsigned char*)mpKey, (unsigned char*)mpInitialisationVector, -1) != 1)
 #else
 	if(EVP_CipherInit(pCipherContext, NULL, (unsigned char*)mKey.c_str(), (unsigned char*)mInitialisationVector, -1) != 1)
 #endif

--- a/lib/crypto/CipherException.txt
+++ b/lib/crypto/CipherException.txt
@@ -16,3 +16,4 @@ PseudoRandNotAvailable				12
 EVPSetPaddingFailure				13
 RandomInitFailed					14	Failed to read from random device
 LengthRequestedTooLongForRandomHex	15
+AlreadyInTransform			16	Tried to initialise crypto when already in a transform

--- a/lib/crypto/Random.cpp
+++ b/lib/crypto/Random.cpp
@@ -50,7 +50,7 @@ void Random::Initialise()
 // --------------------------------------------------------------------------
 void Random::Generate(void *pOutput, int Length)
 {
-	if(RAND_pseudo_bytes((uint8_t*)pOutput, Length) == -1)
+	if(RAND_bytes((uint8_t*)pOutput, Length) == -1)
 	{
 		THROW_EXCEPTION(CipherException, PseudoRandNotAvailable)
 	}

--- a/lib/server/TLSContext.cpp
+++ b/lib/server/TLSContext.cpp
@@ -23,6 +23,17 @@
 #define MAX_VERIFICATION_DEPTH		2
 #define CIPHER_LIST					"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"
 
+// Macros to allow compatibility with OpenSSL 1.0 and 1.1 APIs. See
+// https://github.com/charybdis-ircd/charybdis/blob/release/3.5/libratbox/src/openssl_ratbox.h
+// for the gory details.
+#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER >= 0x10100000L) // OpenSSL >= 1.1
+#	define BOX_TLS_SERVER_METHOD TLS_server_method
+#	define BOX_TLS_CLIENT_METHOD TLS_client_method
+#else // OpenSSL < 1.1
+#	define BOX_TLS_SERVER_METHOD TLSv1_server_method
+#	define BOX_TLS_CLIENT_METHOD TLSv1_client_method
+#endif
+
 // --------------------------------------------------------------------------
 //
 // Function
@@ -67,7 +78,7 @@ void TLSContext::Initialise(bool AsServer, const char *CertificatesFile, const c
 		::SSL_CTX_free(mpContext);
 	}
 
-	mpContext = ::SSL_CTX_new(AsServer?TLSv1_server_method():TLSv1_client_method());
+	mpContext = ::SSL_CTX_new(AsServer ? BOX_TLS_SERVER_METHOD() : BOX_TLS_CLIENT_METHOD());
 	if(mpContext == NULL)
 	{
 		THROW_EXCEPTION(ServerException, TLSAllocationFailed)

--- a/test/crypto/testcrypto.cpp
+++ b/test/crypto/testcrypto.cpp
@@ -266,7 +266,7 @@ int test(int argc, const char *argv[])
 	// Check rolling checksums
 	uint8_t *checkdata_blk = (uint8_t *)malloc(CHECKSUM_DATA_SIZE);
 	uint8_t *checkdata = checkdata_blk;
-	RAND_pseudo_bytes(checkdata, CHECKSUM_DATA_SIZE);
+	RAND_bytes(checkdata, CHECKSUM_DATA_SIZE);
 	for(int size = CHECKSUM_BLOCK_SIZE_BASE; size <= CHECKSUM_BLOCK_SIZE_LAST; ++size)
 	{
 		// Test skip-roll code


### PR DESCRIPTION
Add support for compiling with OpenSSL 1.1, add a preprocessor compatibility layer, replace deprecated function calls, and fix test failures.

Use OpenSSL 1.1.0g for Windows superbuild. Add workaround for incorrect library suffixes searched by FindOpenSSL <https://gitlab.kitware.com/cmake/cmake/issues/17604>.

Fixes #16. Thanks to Chris West (@FauxFaux) for the initial patch!