### PR TITLE
Disable memory leak tracking in release builds

### DIFF
--- a/lib/common/Box.h
+++ b/lib/common/Box.h
@@ -39,7 +39,7 @@
 #include "CommonException.h"
 #include "Logging.h"
 
-#ifndef BOX_RELEASE_BUILD
+#ifndef BOX_RELEASE_BUILD // this is a debug build:
 	extern bool AssertFailuresToSyslog;
 	#define ASSERT_FAILS_TO_SYSLOG_ON {AssertFailuresToSyslog = true;}
 	void BoxDebugAssertFailed(const char *cond, const char *file, int line);
@@ -70,7 +70,7 @@
 	
 	// Exception names
 	#define EXCEPTION_CODENAMES_EXTENDED
-#else
+#else // this is a release build:
 	#define ASSERT_FAILS_TO_SYSLOG_ON
 	#define ASSERT(cond)
 
@@ -80,19 +80,19 @@
 	// Box Backup builds release get extra information for exception logging
 	#define EXCEPTION_CODENAMES_EXTENDED
 	#define EXCEPTION_CODENAMES_EXTENDED_WITH_DESCRIPTION
+
+	#ifdef BOX_MEMORY_LEAK_TESTING
+		#error BOX_MEMORY_LEAK_TESTING should not already be defined in release builds!
+	#endif
 #endif
 
-#if defined DEBUG_LEAKS
+#if defined DEBUG_LEAKS // optionally enable memory leak debugging even in release builds
 	#ifdef PLATFORM_DISABLE_MEM_LEAK_TESTING
 		#error Compiling with DEBUG_LEAKS enabled, but not supported on this platform
 	#else
 		#define BOX_MEMORY_LEAK_TESTING
 	#endif
-#elif defined BOX_RELEASE_BUILD
-	#ifndef PLATFORM_DISABLE_MEM_LEAK_TESTING
-		#define BOX_MEMORY_LEAK_TESTING
-	#endif
-#endif // DEBUG_LEAKS || BOX_RELEASE_BUILD
+#endif // DEBUG_LEAKS
 
 #ifdef BOX_MEMORY_LEAK_TESTING
 	// Memory leak testing

--- a/lib/common/MainHelper.h
+++ b/lib/common/MainHelper.h
@@ -21,9 +21,14 @@
 #include "Logging.h"
 
 #define MAINHELPER_START \
-	if(argc == 2 && ::strcmp(argv[1], "--version") == 0) \
-	{ printf(BOX_VERSION "\n"); return 0; } \
+	/* need to init memleakfinder early because we already called MAINHELPER_SETUP_MEMORY_LEAK_EXIT_REPORT */ \
 	MEMLEAKFINDER_INIT \
+	if(argc == 2 && ::strcmp(argv[1], "--version") == 0) \
+	{ \
+		printf("Version: " BOX_VERSION "\n"); \
+		printf("Build: " BOX_BUILD_SIGNATURE "\n"); \
+		return 0; \
+	} \
 	MEMLEAKFINDER_START \
 	try {
 


### PR DESCRIPTION
This was accidentally enabled in 2013 (then in SVN, now in commit
51d63d54c). It should never have been enabled in release builds.
Thanks to Jack Warkentin for reporting it.