### PR TITLE
libssl3 compatibility + prevent IOStream::Flush to indefinitely loop if the connection has been lost 

### DIFF
--- a/lib/backupstore/HousekeepStoreAccount.cpp
+++ b/lib/backupstore/HousekeepStoreAccount.cpp
@@ -561,7 +561,7 @@ bool HousekeepStoreAccount::ScanDirectory(int64_t ObjectID,
 //		Created: 11/12/03
 //
 // --------------------------------------------------------------------------
-bool HousekeepStoreAccount::DelEnCompare::operator()(const HousekeepStoreAccount::DelEn &x, const HousekeepStoreAccount::DelEn &y)
+bool HousekeepStoreAccount::DelEnCompare::operator()(const HousekeepStoreAccount::DelEn &x, const HousekeepStoreAccount::DelEn &y) const
 {
 	// STL spec says this:
 	// A Strict Weak Ordering is a Binary Predicate that compares two objects, returning true if the first precedes the second.

--- a/lib/backupstore/HousekeepStoreAccount.h
+++ b/lib/backupstore/HousekeepStoreAccount.h
@@ -72,7 +72,7 @@ private:
 	
 	struct DelEnCompare
 	{
-		bool operator()(const DelEn &x, const DelEn &y);
+		bool operator()(const DelEn &x, const DelEn &y) const;
 	};
 	
 	int mAccountID;

--- a/lib/bbackupd/BackupDaemon.cpp
+++ b/lib/bbackupd/BackupDaemon.cpp
@@ -2339,7 +2339,7 @@ void BackupDaemon::SendSyncStartOrFinish(bool SendStart)
 	// by code, rather than the OS.
 	typedef struct
 	{
-		bool operator()(const std::string &s1, const std::string &s2)
+		bool operator()(const std::string &s1, const std::string &s2) const
 		{
 			if(s1.size() == s2.size())
 			{

--- a/lib/common/IOStream.cpp
+++ b/lib/common/IOStream.cpp
@@ -241,7 +241,10 @@ void IOStream::Flush(int Timeout)
 
 	while(StreamDataLeft())
 	{
-		Read(buffer, sizeof(buffer), Timeout);
+		if(Read(buffer, sizeof(buffer), Timeout) == 0) {
+			// Timeout or something went wrong
+			return;
+		}
 	}
 }
 

--- a/lib/crypto/CipherBlowfish.cpp
+++ b/lib/crypto/CipherBlowfish.cpp
@@ -10,6 +10,9 @@
 #include "Box.h"
 
 #include <openssl/evp.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#endif
 
 #ifdef HAVE_OLD_SSL
 	#include <string.h>
@@ -155,8 +158,60 @@ CipherBlowfish &CipherBlowfish::operator=(const CipherBlowfish &rToCopy)
 //		Created: 1/12/03
 //
 // --------------------------------------------------------------------------
+
 const EVP_CIPHER *CipherBlowfish::GetCipher() const
 {
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static OSSL_PROVIDER *legacy_provider = NULL;
+	static OSSL_PROVIDER *default_provider = NULL;
+	static OSSL_LIB_CTX *ossl_ctx = NULL;
+
+	if (!ossl_ctx) {
+		ossl_ctx = OSSL_LIB_CTX_new();
+	}
+	if (!ossl_ctx) {
+		THROW_EXCEPTION(CipherException, UnknownCipherMode)
+	}
+
+	if (!legacy_provider) {
+		legacy_provider = OSSL_PROVIDER_load(ossl_ctx, "legacy");
+	}
+	if (!legacy_provider) {
+		THROW_EXCEPTION(CipherException, UnknownCipherMode)
+	}
+
+	if (!default_provider) {
+		default_provider = OSSL_PROVIDER_load(ossl_ctx, "default");
+	}
+	if (!default_provider) {
+			THROW_EXCEPTION(CipherException, UnknownCipherMode)
+
+	}
+
+	switch(mMode)
+	{
+	case CipherDescription::Mode_ECB:
+		return EVP_CIPHER_fetch(ossl_ctx, "BF-EBC", NULL);
+		break;
+	
+	case CipherDescription::Mode_CBC:
+	    return EVP_CIPHER_fetch(ossl_ctx, "BF-CBC", NULL);
+		break;
+	
+	case CipherDescription::Mode_CFB:
+		return EVP_CIPHER_fetch(ossl_ctx, "BF-CFB", NULL);
+		break;
+	
+	case CipherDescription::Mode_OFB:
+		return EVP_CIPHER_fetch(ossl_ctx, "BF-OFB", NULL);
+		break;
+	
+	default:
+		break;
+	}
+
+#else
 	switch(mMode)
 	{
 	case CipherDescription::Mode_ECB:
@@ -178,6 +233,8 @@ const EVP_CIPHER *CipherBlowfish::GetCipher() const
 	default:
 		break;
 	}
+#endif
+
 
 	// Unknown!
 	THROW_EXCEPTION(CipherException, UnknownCipherMode)


### PR DESCRIPTION
we've got some cases where the connection between the client and the server has been lost causing an infinite loop on the server waiting to flush the stream.
I didn't go for throwing an exception here as it may be a recoverable error, but maybe should I ?